### PR TITLE
[STEP-17/18] Kafka 적용 및 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.retry:spring-retry")
 
+	// Kafka
+	implementation("org.springframework.kafka:spring-kafka:3.0.0")
+
 	// Redis
 	implementation("org.apache.commons:commons-pool2:2.11.1")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis:3.1.5")
@@ -56,6 +59,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
+	testImplementation("org.testcontainers:kafka")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	// Lombok

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
 version: '3'
 services:
+  kafka:
+    image: public.ecr.aws/bitnami/kafka:3.5.1
+    ports:
+      - "9092:9092"
+    volumes:
+      - kafka-data:/bitnami/kafka
+    environment:
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9092
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
   mysql:
     image: mysql:8.0
     ports:
@@ -23,3 +37,6 @@ services:
 networks:
   default:
     driver: bridge
+
+volumes:
+  kafka-data:

--- a/src/main/java/kr/hhplus/be/server/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.config.kafka;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+            ConsumerFactory<String, String> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        // 단일 메시지 처리 모드로 설정 (batch 모드 비활성화)
+        factory.setBatchListener(false);
+        return factory;
+    }
+}
+

--- a/src/main/java/kr/hhplus/be/server/domain/event/ReservationCompletedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/event/ReservationCompletedEvent.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.domain.event;
+
+import kr.hhplus.be.server.domain.entity.reservation.Reservation;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class ReservationCompletedEvent extends ApplicationEvent {
+    private final Reservation reservation;
+
+    public ReservationCompletedEvent(Reservation reservation) {
+        super(reservation);
+        this.reservation = reservation;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/event/listener/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/domain/event/listener/ReservationEventListener.java
@@ -1,0 +1,34 @@
+package kr.hhplus.be.server.domain.event.listener;
+
+import kr.hhplus.be.server.domain.event.ReservationCompletedEvent;
+import kr.hhplus.be.server.domain.outbox.OutboxEventType;
+import kr.hhplus.be.server.domain.outbox.OutboxStatus;
+import kr.hhplus.be.server.domain.outbox.ReservationOutbox;
+import kr.hhplus.be.server.domain.outbox.ReservationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationEventListener {
+
+    private final ReservationOutboxRepository outboxRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleReservationCompletedEventBeforeCommit() {
+        ReservationOutbox outbox = new ReservationOutbox();
+        outbox.setEventType(OutboxEventType.RESERVATION_COMPLETED);
+
+        try {
+            outbox.setStatus(OutboxStatus.PENDING);
+            outboxRepository.save(outbox);
+        } catch (Exception e) {
+            outbox.setStatus(OutboxStatus.FAILED);
+            outboxRepository.save(outbox);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/OutboxEventType.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/OutboxEventType.java
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.domain.outbox;
+
+public enum OutboxEventType {
+    RESERVATION_COMPLETED
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/OutboxStatus.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    SENT,
+    FAILED
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/ReservationOutbox.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/ReservationOutbox.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.domain.outbox;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "reservation_outbox")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReservationOutbox {
+
+    @Id
+    private String id = UUID.randomUUID().toString();
+
+//    @Lob
+//    @Column(nullable = false, columnDefinition = "TEXT")
+//    private String payload;
+
+    @Column(nullable = false)
+    private OutboxEventType eventType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status = OutboxStatus.PENDING;
+
+    private int retryCount = 0;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/ReservationOutboxRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/ReservationOutboxRepository.java
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.domain.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationOutboxRepository extends JpaRepository<ReservationOutbox, String> {
+    ReservationOutbox findByIdAndStatus(Long id, OutboxStatus status);
+    List<ReservationOutbox> findByStatusAndEventType(OutboxStatus status, OutboxEventType eventType);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/kafka/ReservationEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infra/kafka/ReservationEventPublisher.java
@@ -1,0 +1,51 @@
+package kr.hhplus.be.server.infra.kafka;
+
+import kr.hhplus.be.server.domain.outbox.OutboxEventType;
+import kr.hhplus.be.server.domain.outbox.OutboxStatus;
+import kr.hhplus.be.server.domain.outbox.ReservationOutbox;
+import kr.hhplus.be.server.domain.outbox.ReservationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationEventPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ReservationOutboxRepository outboxRepository;
+
+    private static final String TOPIC_RESERVATION = "reservation-complete";
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishPendingReservationCompletedEvent() {
+        List<ReservationOutbox> pendingEvents = outboxRepository.findByStatusAndEventType(
+                OutboxStatus.PENDING, OutboxEventType.RESERVATION_COMPLETED);
+
+        if (pendingEvents.isEmpty()) {
+            return;
+        }
+
+        for (ReservationOutbox event : pendingEvents) {
+            try {
+                kafkaTemplate.send(TOPIC_RESERVATION, event.getId())
+                        .whenComplete((result, ex) -> {
+                            if (ex != null) {
+                                event.setStatus(OutboxStatus.FAILED);
+                                outboxRepository.save(event);
+                            }
+                        });
+            } catch (Exception e) {
+                event.setStatus(OutboxStatus.FAILED);
+                outboxRepository.save(event);
+            }
+        }
+
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/kafka/listener/SelfConsumingListener.java
+++ b/src/main/java/kr/hhplus/be/server/infra/kafka/listener/SelfConsumingListener.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.infra.kafka.listener;
+
+import kr.hhplus.be.server.domain.outbox.OutboxStatus;
+import kr.hhplus.be.server.domain.outbox.ReservationOutbox;
+import kr.hhplus.be.server.domain.outbox.ReservationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SelfConsumingListener {
+
+    private final ReservationOutboxRepository outboxRepository;
+
+    @KafkaListener(topics = "reservation-complete", groupId = "reservation-complete-self")
+    public void updateReservationCompleteMessage(@Payload Long id) {
+        ReservationOutbox outbox = outboxRepository.findByIdAndStatus(id, OutboxStatus.PENDING);
+        if (outbox != null) {
+            outbox.setStatus(OutboxStatus.SENT);
+            outboxRepository.save(outbox);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/scheduler/outbox/OutboxEventPublisherScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/scheduler/outbox/OutboxEventPublisherScheduler.java
@@ -1,0 +1,52 @@
+package kr.hhplus.be.server.interfaces.scheduler.outbox;
+
+import kr.hhplus.be.server.domain.outbox.OutboxEventType;
+import kr.hhplus.be.server.domain.outbox.OutboxStatus;
+import kr.hhplus.be.server.domain.outbox.ReservationOutbox;
+import kr.hhplus.be.server.domain.outbox.ReservationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPublisherScheduler {
+    private final ReservationOutboxRepository outboxRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    private static final String TOPIC_RESERVATION = "reservation-notification";
+
+    @Scheduled(fixedDelay = 10000)
+    @Transactional
+    public void republishReservationKafkaEvents() {
+
+        List<ReservationOutbox> targetEvents = new ArrayList<>();
+
+        targetEvents.addAll(outboxRepository.findByStatusAndEventType(OutboxStatus.PENDING, OutboxEventType.RESERVATION_COMPLETED));
+        targetEvents.addAll(outboxRepository.findByStatusAndEventType(OutboxStatus.FAILED, OutboxEventType.RESERVATION_COMPLETED));
+
+        if(targetEvents.isEmpty()) return;
+
+        for (ReservationOutbox event : targetEvents) {
+            try {
+                kafkaTemplate.send(TOPIC_RESERVATION, event.getId())
+                        .whenComplete((result, ex) -> {
+                            if (ex != null) {
+                                event.setStatus(OutboxStatus.FAILED);
+                                outboxRepository.save(event);
+                            }
+                        });
+            } catch (Exception e) {
+                event.setStatus(OutboxStatus.FAILED);
+                outboxRepository.save(event);
+            }
+        }
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,21 +1,30 @@
-#spring:
-#  application:
-#    name: concert
-#
-#  profiles:
-#    default: local
-#
-#  datasource:
-#    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
-#    username: root
-#    password: hhplus2025
-#    type: com.zaxxer.hikari.HikariDataSource
-#    hikari:
-#      maximum-pool-size: 3
-#      connection-timeout: 10000
-#      max-lifetime: 60000
-
 spring:
+
+  kafka:
+    bootstrap-servers: localhost:9094
+    properties:
+      security.protocol: PLAINTEXT
+      request.timeout.ms: 20000
+      retry.backoff.ms: 500
+      auto:
+        offset.reset: earliest
+        register.schemas: false
+        create.topics.enable: false
+      use.latest.version: true
+      basic.auth.credentials.source: USER_INFO
+    producer:
+      client-id: ${spring.application.name}
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      retries: 5
+    consumer:
+      group-id: ${spring.application.name}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      properties:
+        enable-auto-commit: false
+    listener:
+      ack-mode: manual
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,33 @@ spring:
       maximum-pool-size: 3
       connection-timeout: 10000
       max-lifetime: 60000
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    properties:
+      security.protocol: PLAINTEXT
+      request.timeout.ms: 20000
+      retry.backoff.ms: 500
+      auto:
+        offset.reset: earliest
+        register.schemas: false
+        create.topics.enable: false
+      use.latest.version: true
+      basic.auth.credentials.source: USER_INFO
+    producer:
+      client-id: ${spring.application.name}
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      retries: 5
+    consumer:
+      group-id: ${spring.application.name}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      properties:
+        enable-auto-commit: false
+    listener:
+      ack-mode: manual
+
   data:
     redis:
       host: 127.0.0.1

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
@@ -14,6 +16,8 @@ class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
 	public static final GenericContainer<?> REDIS_CONTAINER;
+	public static final KafkaContainer KAFKA_CONTAINER;
+
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -26,12 +30,17 @@ class TestcontainersConfiguration {
 				.withExposedPorts(6379);
 		REDIS_CONTAINER.start();
 
+		KAFKA_CONTAINER = new KafkaContainer("apache/kafka-native:3.8.0");
+		KAFKA_CONTAINER.start();
+
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
 
 		System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
 		System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+
+		System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
 	}
 
 	@PreDestroy
@@ -41,6 +50,9 @@ class TestcontainersConfiguration {
 		}
 		if (REDIS_CONTAINER.isRunning()) {
 			REDIS_CONTAINER.stop();
+		}
+		if(KAFKA_CONTAINER.isRunning()) {
+			KAFKA_CONTAINER.stop();
 		}
 	}
 }


### PR DESCRIPTION
## 커밋링크 
- 카프카 설정 및 통합 테스트
[설정] ae6174e8ac37def18eab6ef43a3b95f1cfb365e6
[통합 테스트] https://wiry-skink-7c7.notion.site/STEP-17-Kafka-19f648bd41928055a627dad0d27640a5?pvs=4

- 예약 결제 완료 후 카프카로 메시지 전송 및 Transactional Outbox pattern 적용
[구현] c5fb5babd44cf84642633deb2cc1555a28e04dfd
[보고서] https://wiry-skink-7c7.notion.site/STEP-18-Kafka-19e648bd419280859ca1c0c1fe2178ee?pvs=4

## 리뷰 포인트
1. Kafka 토픽 네이밍 컨벤션
현재 PR에서는 Kafka 토픽명을 "reservation-complete"으로 설정했는데, 현업에서는 일반적으로 어떤 네이밍 컨벤션을 따르는지 궁금합니다.
- 도메인 기반: reservation.notification, payment.processed
- 이벤트 중심(과거형): reservation-completed, user-registered
- 조직/서비스 단위: platform.reservation.completed

2. Kafka 메시지 재시도 로직
현재 Kafka 메시지 전송 실패 시 FAILED로 설정 후 스케줄러가 재시도하는 방식인데, 무한 재시도를 방지하고 운영 측면에서 관리할 방법이 필요할까요?

- 시도 횟수를 제한하는 것이 적절할지 (retry_count 추가 등)
- 최대 재시도 초과 시 FAILED 상태로만 두는 것이 적절할지, 운영자가 실패 이벤트를 추적하고 대응할 수 있도록 별도 모니터링 방식이 필요할지

3. 아웃박스 패턴이 적절하게 구현되어 있는지 확인 부탁드립니다.
4. 작성된 보고서가 적절하게 정리되었는지, 보완할 내용이 있는지 피드백 부탁드립니다.


## 이번주 KPT 회고
Keep : 
멘토링/청강 적극 참여

Problem : 
기술 사용에 중점을 둔 개발 습관

Try :
비즈니스 로직 구현을 위한 기술 사용하기 (주객 전도 되지 않기)
마지막 한 주 화이팅하기!
